### PR TITLE
Add InjectOptional attribute and Pin.LoadScene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ sysinfo.txt
 #*.unitypackage
 
 .DS_Store
+
+# Rider
+/.idea/

--- a/Runtime/Core/API/Pin.LoadScene.cs
+++ b/Runtime/Core/API/Pin.LoadScene.cs
@@ -1,0 +1,33 @@
+﻿// PinInject, Maxwell Keonwoo Kang <code.athei@gmail.com>, 2022
+
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Cathei.PinInject
+{
+    public static partial class Pin
+    {
+        internal static ContextConfiguration sceneContextConfig = null;
+        
+        /// <summary>
+        /// Load and inject config a Scene.
+        /// </summary>
+        public static void LoadScene(string sceneName, LoadSceneMode loadSceneMode, ContextConfiguration config = null)
+        {
+            sceneContextConfig = config;
+            SceneManager.LoadScene(sceneName, loadSceneMode);
+        }
+
+        /// <summary>
+        /// Load and inject config a Scene.
+        /// </summary>
+        /// <remarks>
+        /// Note: Calling this method in parallel may result in improper injection of the Configuration.
+        /// </remarks>
+        public static AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, ContextConfiguration config = null)
+        {
+            sceneContextConfig = config;
+            return SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
+        }
+    }
+}

--- a/Runtime/Core/API/Pin.LoadScene.cs
+++ b/Runtime/Core/API/Pin.LoadScene.cs
@@ -1,5 +1,6 @@
 ﻿// PinInject, Maxwell Keonwoo Kang <code.athei@gmail.com>, 2022
 
+using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -28,6 +29,18 @@ namespace Cathei.PinInject
         {
             sceneContextConfig = config;
             return SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
+        }
+        
+        /// <summary>
+        /// Load and inject config a Scene.
+        /// </summary>
+        /// <remarks>
+        /// Note: Calling this method in parallel may result in improper injection of the Configuration.
+        /// </remarks>
+        public static T LoadSceneAsync<T>(Func<T> loadSceneFunc, ContextConfiguration config = null)
+        {
+            sceneContextConfig = config;
+            return loadSceneFunc();
         }
     }
 }

--- a/Runtime/Core/API/Pin.LoadScene.cs.meta
+++ b/Runtime/Core/API/Pin.LoadScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3698d761233c490a8f911cd7bd6cb785
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Core/API/Pin.SceneManagement.cs
+++ b/Runtime/Core/API/Pin.SceneManagement.cs
@@ -65,7 +65,7 @@ namespace Cathei.PinInject
             }
         }
 
-        internal static void SetUpScene(SceneCompositionRoot compositionRoot)
+        internal static void SetUpScene(SceneCompositionRoot compositionRoot, ContextConfiguration config = null)
         {
             var compositionRootObject = compositionRoot.gameObject;
             var scene = compositionRootObject.scene;
@@ -76,7 +76,7 @@ namespace Cathei.PinInject
             var persistentContainer = SetUpPersistent(compositionRoot.parent);
 
             // inject scene first
-            UnityStrategy.Inject(compositionRootObject, persistentContainer, null);
+            UnityStrategy.Inject(compositionRootObject, persistentContainer, config);
 
             var sceneContainer = compositionRootObject.GetOrAddContainerComponent();
 

--- a/Runtime/Core/Common/DefaultInjectionStrategy.cs
+++ b/Runtime/Core/Common/DefaultInjectionStrategy.cs
@@ -70,7 +70,7 @@ namespace Cathei.PinInject.Internal
             {
                 var value = container.Resolve(injectable.Type, injectable.IdGetter(obj));
 
-                if (value == null)
+                if (value == null && !injectable.Optional)
                     throw new InjectionException($"Type {injectable.Type} on {obj} cannot be resolved");
 
                 injectable.Setter(obj, value);

--- a/Runtime/Core/Reflection/InjectAttribute.cs
+++ b/Runtime/Core/Reflection/InjectAttribute.cs
@@ -13,10 +13,12 @@ namespace Cathei.PinInject
     {
         public readonly string Name;
         public readonly bool FromMember;
+        public readonly bool Optional = false;
 
-        public InjectAttribute()
+        public InjectAttribute(bool optional = false)
         {
             Name = null;
+            Optional = optional;
         }
 
         public InjectAttribute(string name, bool fromMember = false)

--- a/Runtime/Core/Reflection/InjectOptionalAttribute.cs
+++ b/Runtime/Core/Reflection/InjectOptionalAttribute.cs
@@ -1,0 +1,15 @@
+﻿// PinInject, Maxwell Keonwoo Kang <code.athei@gmail.com>, 2022
+
+using System;
+using Cathei.PinInject;
+
+namespace Core.Reflection
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class InjectOptionalAttribute : InjectAttribute
+    {
+        public InjectOptionalAttribute() : base(optional: true)
+        {
+        }
+    }
+}

--- a/Runtime/Core/Reflection/InjectOptionalAttribute.cs.meta
+++ b/Runtime/Core/Reflection/InjectOptionalAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 347b8889b8244d319bd2e01a2de62f1d
+timeCreated: 1698764791

--- a/Runtime/Core/Reflection/ReflectionCache.cs
+++ b/Runtime/Core/Reflection/ReflectionCache.cs
@@ -63,7 +63,7 @@ namespace Cathei.PinInject.Internal
 
                     _injectables ??= new List<InjectableProperty>();
                     _injectables.Add(new InjectableProperty(
-                        prop.PropertyType, IdGetter(type, injectAttr), prop.SetValue));
+                        prop.PropertyType, IdGetter(type, injectAttr), prop.SetValue, injectAttr.Optional));
                 }
 
                 if (resolveAttr != null)
@@ -85,7 +85,7 @@ namespace Cathei.PinInject.Internal
                 {
                     _injectables ??= new List<InjectableProperty>();
                     _injectables.Add(new InjectableProperty(
-                        field.FieldType, IdGetter(type, injectAttr), field.SetValue));
+                        field.FieldType, IdGetter(type, injectAttr), field.SetValue, injectAttr.Optional));
                 }
 
                 if (resolveAttr != null)
@@ -127,12 +127,14 @@ namespace Cathei.PinInject.Internal
             public readonly Type Type;
             public readonly Func<object, string> IdGetter;
             public readonly Action<object, object> Setter;
+            public readonly bool Optional;
 
-            public InjectableProperty(Type type, Func<object, string> idGetter, Action<object, object> setter)
+            public InjectableProperty(Type type, Func<object, string> idGetter, Action<object, object> setter, bool optional)
             {
                 Type = type;
                 IdGetter = idGetter;
                 Setter = setter;
+                Optional = optional;
             }
         }
 

--- a/Runtime/Core/Unity/SceneCompositionRoot.cs
+++ b/Runtime/Core/Unity/SceneCompositionRoot.cs
@@ -17,7 +17,7 @@ namespace Cathei.PinInject
 
         private void Awake()
         {
-            Pin.SetUpScene(this);
+            Pin.SetUpScene(this, Pin.sceneContextConfig);
         }
 
         private void OnDestroy()


### PR DESCRIPTION
`Pin.LoadScene` can be used to Bind the type to the scene to be loaded.

`InjectOptional` allows null to be injected without throwing an exception if the interface is not Bind.

## Usage Example

The main use case is to pass initial values to the Scene.
However, when initial values are received in Inject, an error occurs if the initial values are not assigned, making it impossible to check the Scene alone from the Editor.
InjectOptional is used in such cases.
If the initial value is not Bind, the initial value for testing can be passed, and thus can be checked by Scene alone.

```c#
   public class SceneLoader : MonoBehaviour,
        IHogeSceneLoader
    {
        [SerializeField] private string _sceneName;

        async UniTask IHogeSceneLoader.LoadSceneAsync(HogeSceneConfig config, CancellationToken cancellationToken)
        {
            await Pin.LoadSceneAsync(_sceneName, LoadSceneMode.Additive, (binder) => binder.Bind(config))
                .ToUniTask(cancellationToken: cancellationToken);
        }
    }
``` 

```c#
public class HogeSceneInstaller : MonoBehaviour, IInjectionContext
{  
    [InjectOptional] private HogeSceneConfig _config;  
  
    void IInjectionContext.Configure(DependencyBinder binder)  
    {       
         _config ??= new HogeSceneConfig("TestValue");
        ... 
    }
}

``` 